### PR TITLE
#122 - Make error locations in bucklescript tool window clickable

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -311,6 +311,7 @@
 
         <codeInsight.parameterInfo language="Reason"
                                    implementationClass="com.reason.ide.hints.ORParameterInfoHandlerWithTabActionSupport"/>
+        <consoleFilterProvider implementation="com.reason.build.console.BsConsoleFilterProvider"/>
     </extensions>
 
 </idea-plugin>

--- a/src/com/reason/build/console/BsConsoleFilter.java
+++ b/src/com/reason/build/console/BsConsoleFilter.java
@@ -1,0 +1,38 @@
+package com.reason.build.console;
+
+import java.util.regex.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import com.intellij.execution.filters.Filter;
+import com.intellij.execution.filters.OpenFileHyperlinkInfo;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+
+import static java.lang.Integer.parseInt;
+
+public class BsConsoleFilter implements Filter {
+    private final static Pattern LINE_PATTERN = Pattern.compile("^\\s*(.+.(?:rei|re|mli|ml))\\s([0-9]+):([0-9]+)-.+$");
+
+    private final Project m_project;
+
+    BsConsoleFilter(@NotNull Project project) {
+        m_project = project;
+    }
+
+    @Nullable
+    @Override
+    public Result applyFilter(@NotNull String line, int entireLength) {
+        int startPoint = entireLength - line.length();
+        Matcher matcher = LINE_PATTERN.matcher(line);
+        if (matcher.find()) {
+            String filePath = matcher.group(1);
+            VirtualFile virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(filePath);
+            if (virtualFile != null) {
+                return new Result(startPoint + matcher.start(1), entireLength,
+                                  new OpenFileHyperlinkInfo(m_project, virtualFile, parseInt(matcher.group(2)) - 1, parseInt(matcher.group(3)) - 1));
+            }
+        }
+        return null;
+    }
+}

--- a/src/com/reason/build/console/BsConsoleFilterProvider.java
+++ b/src/com/reason/build/console/BsConsoleFilterProvider.java
@@ -1,0 +1,14 @@
+package com.reason.build.console;
+
+import org.jetbrains.annotations.NotNull;
+import com.intellij.execution.filters.ConsoleFilterProvider;
+import com.intellij.execution.filters.Filter;
+import com.intellij.openapi.project.Project;
+
+public class BsConsoleFilterProvider implements ConsoleFilterProvider {
+    @NotNull
+    @Override
+    public Filter[] getDefaultFilters(@NotNull Project project) {
+        return new Filter[]{new BsConsoleFilter(project)};
+    }
+}


### PR DESCRIPTION
Add a feature to make error link clickable.
![image](https://user-images.githubusercontent.com/9803015/52116318-26470980-2611-11e9-97b3-0c6acac41d52.png)