### PR TITLE
Clickable Error locations - Fix regex for message only containing warning start

### DIFF
--- a/src/com/reason/build/console/BsConsoleFilter.java
+++ b/src/com/reason/build/console/BsConsoleFilter.java
@@ -12,7 +12,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import static java.lang.Integer.parseInt;
 
 public class BsConsoleFilter implements Filter {
-    private final static Pattern LINE_PATTERN = Pattern.compile("^\\s*(.+.(?:rei|re|mli|ml))\\s([0-9]+):([0-9]+)-.+$");
+    private final static Pattern LINE_PATTERN = Pattern.compile("^\\s*(.+.(?:rei|re|mli|ml))\\s([0-9]+):([0-9]+)[-0-9:\\s]*$");
 
     private final Project m_project;
 


### PR DESCRIPTION
Fix an issue where some error messages where not clickable (because not detected).

The following type of error message should now be supported:
```
  /path/src/Source.re 111:21-112:22
  /path/src/Source.re 111:21-22
  /path/src/Source.re 111:21
```