### PR TITLE
[WIP] Variant syntax highlighting.

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -235,9 +235,6 @@
         <colorSettingsPage implementation="com.reason.ide.settings.ReasonColorSettingsPage"/>
         <colorSettingsPage implementation="com.reason.ide.settings.DuneColorSettingsPage"/>
 
-        <additionalTextAttributes scheme="Default" file="colorSchemes/ReasonDefault.xml"/>
-        <additionalTextAttributes scheme="Darcula" file="colorSchemes/ReasonDarcula.xml"/>
-
         <annotator language="Reason" implementationClass="com.reason.ide.highlight.RmlSyntaxAnnotator"/>
         <annotator language="OCaml" implementationClass="com.reason.ide.highlight.OclSyntaxAnnotator"/>
 

--- a/resources/colorSchemes/ReasonDarcula.xml
+++ b/resources/colorSchemes/ReasonDarcula.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<list>
-    <option name="REASONML_OPTION">
-        <value>
-            <option name="FOREGROUND" value="9876AA"/>
-            <option name="FONT_TYPE" value="1"/>
-        </value>
-    </option>
-</list>

--- a/resources/colorSchemes/ReasonDefault.xml
+++ b/resources/colorSchemes/ReasonDefault.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<list>
-    <option name="REASONML_OPTION">
-        <value>
-            <option name="FOREGROUND" value="660E7A"/>
-            <option name="FONT_TYPE" value="1"/>
-        </value>
-    </option>
-</list>

--- a/src/com/reason/ide/highlight/ORSyntaxHighlighter.java
+++ b/src/com/reason/ide/highlight/ORSyntaxHighlighter.java
@@ -103,7 +103,7 @@ public class ORSyntaxHighlighter extends SyntaxHighlighterBase {
     public static final TextAttributesKey NUMBER_ = createTextAttributesKey("REASONML_NUMBER", DefaultLanguageHighlighterColors.NUMBER);
     public static final TextAttributesKey MARKUP_TAG_ = createTextAttributesKey("REASONML_MARKUP_TAG", DefaultLanguageHighlighterColors.MARKUP_TAG);
     public static final TextAttributesKey MARKUP_ATTRIBUTE_ = createTextAttributesKey("REASONML_MARKUP_ATTRIBUTE", DefaultLanguageHighlighterColors.MARKUP_ATTRIBUTE);
-    public static final TextAttributesKey OPTION_ = createTextAttributesKey("REASONML_OPTION");
+    public static final TextAttributesKey OPTION_ = createTextAttributesKey("REASONML_OPTION", DefaultLanguageHighlighterColors.STATIC_FIELD);
     public static final TextAttributesKey KEYWORD_ = createTextAttributesKey("REASONML_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD);
     public static final TextAttributesKey SEMICOLON_ = createTextAttributesKey("REASONML_SEMICOLON", DefaultLanguageHighlighterColors.SEMICOLON);
     public static final TextAttributesKey BRACKETS_ = createTextAttributesKey("REASONML_BRACKETS", DefaultLanguageHighlighterColors.BRACKETS);

--- a/src/com/reason/ide/highlight/ORSyntaxHighlighter.java
+++ b/src/com/reason/ide/highlight/ORSyntaxHighlighter.java
@@ -98,7 +98,7 @@ public class ORSyntaxHighlighter extends SyntaxHighlighterBase {
     public static final TextAttributesKey CODE_LENS_ = createTextAttributesKey("REASONML_CODE_LENS", DefaultLanguageHighlighterColors.BLOCK_COMMENT);
     public static final TextAttributesKey RML_COMMENT_ = createTextAttributesKey("REASONML_COMMENT", DefaultLanguageHighlighterColors.BLOCK_COMMENT);
     public static final TextAttributesKey MODULE_NAME_ = createTextAttributesKey("REASONML_MODULE_NAME", DefaultLanguageHighlighterColors.CLASS_NAME);
-    public static final TextAttributesKey VARIANT_NAME_ = createTextAttributesKey("REASONML_VARIANT_NAME", DefaultLanguageHighlighterColors.CLASS_NAME);
+    public static final TextAttributesKey VARIANT_NAME_ = createTextAttributesKey("REASONML_VARIANT_NAME", DefaultLanguageHighlighterColors.STATIC_FIELD);
     public static final TextAttributesKey STRING_ = createTextAttributesKey("REASONML_STRING", DefaultLanguageHighlighterColors.STRING);
     public static final TextAttributesKey NUMBER_ = createTextAttributesKey("REASONML_NUMBER", DefaultLanguageHighlighterColors.NUMBER);
     public static final TextAttributesKey MARKUP_TAG_ = createTextAttributesKey("REASONML_MARKUP_TAG", DefaultLanguageHighlighterColors.MARKUP_TAG);


### PR DESCRIPTION
This PR partially addresses #182. I don't know if removing specialized handling of the Option type is controversial. I can't see why it should be different than other variant types and suspect its special status is historical in nature. For what it's worth, my "expectation" of what the syntax highlighting should look like is highly influenced by the Rust plugin. I appreciate ReasonML may want to adopt colors that match other IDEs that support ReasonML, but I think there's value in matching established highlighting patterns used by other languages in the IntelliJ platform.

If there are no objections to the changes as I have them, I'll take a second pass and remove the Option type highlighting parameter entirely. As of now, if you've provided a customized value for it, it will still be honored.

If there are no objections to that, then I think the next clean-up task might be removing Option's special status in the parser. I would track that work in a separate PR.