### PR TITLE
Added Support for Dune in Esy Context

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ repositories {
 
 dependencies {
     compile project('jps-plugin')
-    testCompile "org.mockito:mockito-core:2.+"
 }
 
 apply plugin: 'idea'

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ repositories {
 
 dependencies {
     compile project('jps-plugin')
+    testCompile "org.mockito:mockito-core:2.+"
 }
 
 apply plugin: 'idea'

--- a/jps-plugin/src/com/reason/Platform.java
+++ b/jps-plugin/src/com/reason/Platform.java
@@ -24,6 +24,7 @@ public class Platform {
     public static final String LOCAL_NODE_MODULES_BIN = "/node_modules/.bin";
     public static final String DUNE_NAME = "dune-project";
     public static final String PACKAGE_JSON_NAME = "package.json";
+    public static final String ESY_PROJECT_IDENTIFIER = "_esy";
     public static final String BSCONFIG_JSON_NAME = "bsconfig.json";
     public static final Charset UTF8 = StandardCharsets.UTF_8;
 
@@ -76,46 +77,40 @@ public class Platform {
         return rootContents;
     }
 
-    public static VirtualFile findORDuneContentRoot(@NotNull Project project) {
-        Map<Module, VirtualFile> rootContents = findContentRootsFor(project, DUNE_NAME);
+    public static VirtualFile findContentRootFor(@NotNull Project project, @NotNull String filename) {
+        Map<Module, VirtualFile> rootContents = findContentRootsFor(project, filename);
 
         if (rootContents.isEmpty()) {
-            LOG.warn("No content roots with " + DUNE_NAME + " file found");
+            LOG.warn("No content roots with " + filename + " file found");
             return null;
         } else if (rootContents.size() == 1) {
             Module module = rootContents.keySet().iterator().next();
-            VirtualFile packageJson = rootContents.get(module);
-            return packageJson.getParent();
+            VirtualFile file = rootContents.get(module);
+            return file.getParent();
         } else {
             Module module = rootContents.keySet().iterator().next();
-            VirtualFile packageJson = rootContents.get(module);
-            LOG.info("Many modules with " + DUNE_NAME + " file in it found (" + rootContents.size() + "), using first", rootContents);
-            return packageJson.getParent();
+            VirtualFile file = rootContents.get(module);
+            LOG.info("Many modules with " + filename + " file in it found (" + rootContents.size() + "), using first", rootContents);
+            return file.getParent();
         }
+    }
+
+    public static VirtualFile findORDuneContentRoot(@NotNull Project project) {
+        return findContentRootFor(project, DUNE_NAME);
+    }
+
+    public static VirtualFile findOREsyContentRoot(@NotNull Project project) {
+        return findContentRootFor(project, ESY_PROJECT_IDENTIFIER);
     }
 
     @Nullable
     public static VirtualFile findORPackageJsonContentRoot(@NotNull Project project) {
-        Map<Module, VirtualFile> rootContents = findContentRootsFor(project, PACKAGE_JSON_NAME);
-
-        if (rootContents.isEmpty()) {
-            LOG.warn("No content roots with " + PACKAGE_JSON_NAME + " file found");
-            return null;
-        } else if (rootContents.size() == 1) {
-            Module module = rootContents.keySet().iterator().next();
-            VirtualFile packageJson = rootContents.get(module);
-            return packageJson.getParent();
-        } else {
-            Module module = rootContents.keySet().iterator().next();
-            VirtualFile packageJson = rootContents.get(module);
-            LOG.info("Many modules with " + PACKAGE_JSON_NAME + " file in it found (" + rootContents.size() + "), using first", rootContents);
-            return packageJson.getParent();
-        }
+        return findContentRootFor(project, PACKAGE_JSON_NAME);
     }
 
     @Nullable
     public static VirtualFile findProjectBsconfig(@NotNull Project project) {
-        VirtualFile contentRoot = Platform.findORPackageJsonContentRoot(project);
+        VirtualFile contentRoot = findORPackageJsonContentRoot(project);
         return contentRoot == null ? null : contentRoot.findChild(BSCONFIG_JSON_NAME);
     }
 

--- a/resources/META-INF/java-deps.xml
+++ b/resources/META-INF/java-deps.xml
@@ -30,6 +30,10 @@
         <projectService serviceImplementation="com.reason.dune.DuneCompiler"/>
         <projectService serviceImplementation="com.reason.dune.DuneProcess"/>
 
+        <!-- Esy -->
+
+        <projectService serviceImplementation="com.reason.esy.EsyProcess"/>
+
         <!-- Gutter icons -->
 
         <codeInsight.lineMarkerProvider language="Reason"

--- a/src/com/reason/CompilerProcess.java
+++ b/src/com/reason/CompilerProcess.java
@@ -1,0 +1,16 @@
+package com.reason;
+
+import com.intellij.execution.process.ProcessHandler;
+import com.reason.ide.console.CliType;
+
+public interface CompilerProcess {
+
+    boolean start();
+
+    void startNotify();
+
+    ProcessHandler recreate(CliType cliType, Compiler.ProcessTerminated onProcessTerminated);
+
+    void terminate();
+
+}

--- a/src/com/reason/CompilerProcessLifecycle.java
+++ b/src/com/reason/CompilerProcessLifecycle.java
@@ -1,7 +1,0 @@
-package com.reason;
-
-public interface CompilerProcessLifecycle {
-
-    void terminated();
-
-}

--- a/src/com/reason/bs/BsOutputListener.java
+++ b/src/com/reason/bs/BsOutputListener.java
@@ -44,7 +44,7 @@ public class BsOutputListener implements RawProcessListener {
 
     @Override
     public void processTerminated(@NotNull ProcessEvent event) {
-        m_compiler.terminated();
+        m_compiler.terminate();
 
         //if (m_lineProcessor.hasInfo() && !m_project.isDisposed()) {
         //    ErrorsManager errorsService = ServiceManager.getService(m_project, ErrorsManager.class);

--- a/src/com/reason/bs/BsProcess.java
+++ b/src/com/reason/bs/BsProcess.java
@@ -8,7 +8,7 @@ import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.reason.Compiler;
-import com.reason.CompilerProcessLifecycle;
+import com.reason.CompilerProcess;
 import com.reason.Platform;
 import com.reason.ide.ORNotification;
 import com.reason.ide.console.CliType;
@@ -28,7 +28,7 @@ import static com.intellij.notification.NotificationType.ERROR;
 import static com.reason.bs.BsBinaries.getBsbPath;
 import static com.reason.bs.BsBinaries.getBscPath;
 
-public final class BsProcess implements CompilerProcessLifecycle {
+public final class BsProcess implements CompilerProcess {
 
     private static final Pattern BS_VERSION_REGEXP = Pattern.compile(".*OCaml[:]?(\\d\\.\\d+.\\d+).+\\)");
 
@@ -48,7 +48,8 @@ public final class BsProcess implements CompilerProcessLifecycle {
     }
 
     // Wait for the tool window to be ready before starting the process
-    void startNotify() {
+    @Override
+    public void startNotify() {
         if (m_bsb != null && !m_bsb.isStartNotified()) {
             try {
                 m_bsb.startNotify();
@@ -68,8 +69,13 @@ public final class BsProcess implements CompilerProcessLifecycle {
         }
     }
 
+    @Override
+    public ProcessHandler recreate(@NotNull CliType cliType, @Nullable Compiler.ProcessTerminated onProcessTerminated) {
+        throw new RuntimeException("Method not yet implemented.");
+    }
+
     @Nullable
-    ProcessHandler recreate(@NotNull VirtualFile sourceFile, @NotNull CliType cliType, @Nullable Compiler.ProcessTerminated onProcessTerminated) {
+    public ProcessHandler recreate(@NotNull VirtualFile sourceFile, @NotNull CliType cliType, @Nullable Compiler.ProcessTerminated onProcessTerminated) {
         try {
             return createProcessHandler(sourceFile, cliType, onProcessTerminated);
         } catch (ExecutionException e) {
@@ -137,6 +143,7 @@ public final class BsProcess implements CompilerProcessLifecycle {
         return cli;
     }
 
+    @Override
     public boolean start() {
         boolean success = m_started.compareAndSet(false, true);
         if (!success) {
@@ -145,7 +152,8 @@ public final class BsProcess implements CompilerProcessLifecycle {
         return success;
     }
 
-    public void terminated() {
+    @Override
+    public void terminate() {
         m_bsb = null;
         m_started.set(false);
     }

--- a/src/com/reason/bs/BucklescriptImpl.java
+++ b/src/com/reason/bs/BucklescriptImpl.java
@@ -86,7 +86,7 @@ public class BucklescriptImpl implements Bucklescript {
                         process.startNotify();
                         ServiceManager.getService(m_project, InsightManager.class).downloadRincewindIfNeeded(sourceFile);
                     } else {
-                        process.terminated();
+                        process.terminate();
                     }
                 }
             }

--- a/src/com/reason/dune/DuneOutputListener.java
+++ b/src/com/reason/dune/DuneOutputListener.java
@@ -14,7 +14,7 @@ import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.reason.CompilerProcessLifecycle;
+import com.reason.CompilerProcess;
 import com.reason.Platform;
 import com.reason.ide.annotations.ErrorsManager;
 import com.reason.ide.annotations.OutputInfo;
@@ -32,7 +32,7 @@ public class DuneOutputListener implements ProcessListener {
 
     @NotNull
     private final Project m_project;
-    private final CompilerProcessLifecycle m_compilerLifecycle;
+    private final CompilerProcess m_compilerLifecycle;
     @NotNull
     private final Logger m_log;
     private final List<OutputInfo> m_bsbInfo = new ArrayList<>();
@@ -40,7 +40,7 @@ public class DuneOutputListener implements ProcessListener {
     @Nullable
     private OutputInfo m_latestInfo = null;
 
-    DuneOutputListener(@NotNull Project project, CompilerProcessLifecycle compilerLifecycle) {
+    public DuneOutputListener(@NotNull Project project, CompilerProcess compilerLifecycle) {
         m_project = project;
         m_compilerLifecycle = compilerLifecycle;
         m_log = Logger.getInstance("ReasonML.build");
@@ -58,7 +58,7 @@ public class DuneOutputListener implements ProcessListener {
 
     @Override
     public void processTerminated(@NotNull ProcessEvent event) {
-        m_compilerLifecycle.terminated();
+        m_compilerLifecycle.terminate();
 
         if (!m_bsbInfo.isEmpty()) {
             ServiceManager.getService(m_project, ErrorsManager.class).addAllInfo(m_bsbInfo);

--- a/src/com/reason/dune/DuneProcess.java
+++ b/src/com/reason/dune/DuneProcess.java
@@ -20,7 +20,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.reason.Compiler;
-import com.reason.CompilerProcessLifecycle;
+import com.reason.CompilerProcess;
 import com.reason.OCamlSdkType;
 import com.reason.Platform;
 import com.reason.ide.ORNotification;
@@ -29,7 +29,7 @@ import com.reason.ide.console.CliType;
 import static com.intellij.notification.NotificationListener.URL_OPENING_LISTENER;
 import static com.intellij.notification.NotificationType.ERROR;
 
-public final class DuneProcess implements CompilerProcessLifecycle {
+public final class DuneProcess implements CompilerProcess {
 
     @NotNull
     private final Project m_project;
@@ -49,7 +49,8 @@ public final class DuneProcess implements CompilerProcessLifecycle {
     }
 
     // Wait for the tool window to be ready before starting the process
-    void startNotify() {
+    @Override
+    public void startNotify() {
         if (m_processHandler != null && !m_processHandler.isStartNotified()) {
             try {
                 m_processHandler.startNotify();
@@ -59,8 +60,9 @@ public final class DuneProcess implements CompilerProcessLifecycle {
         }
     }
 
+    @Override
     @Nullable
-    ProcessHandler recreate(@NotNull CliType cliType, @Nullable Compiler.ProcessTerminated onProcessTerminated) {
+    public ProcessHandler recreate(@NotNull CliType cliType, @Nullable Compiler.ProcessTerminated onProcessTerminated) {
         try {
             killIt();
             GeneralCommandLine cli = getGeneralCommandLine(cliType);
@@ -139,12 +141,13 @@ public final class DuneProcess implements CompilerProcessLifecycle {
         return cli;
     }
 
+    @Override
     public boolean start() {
         return m_started.compareAndSet(false, true);
     }
 
     @Override
-    public void terminated() {
+    public void terminate() {
         m_started.set(false);
     }
 }

--- a/src/com/reason/esy/EsyProcess.java
+++ b/src/com/reason/esy/EsyProcess.java
@@ -1,0 +1,278 @@
+package com.reason.esy;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.configurations.PathEnvironmentVariableUtil;
+import com.intellij.execution.process.*;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.reason.Compiler;
+import com.reason.CompilerProcess;
+import com.reason.Log;
+import com.reason.Platform;
+import com.reason.dune.DuneOutputListener;
+import com.reason.ide.ORNotification;
+import com.reason.ide.console.CliType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import static com.intellij.notification.NotificationType.ERROR;
+import static com.reason.esy.EsyProcessException.esyNotFoundException;
+
+public class EsyProcess implements CompilerProcess {
+
+  public static final String DUNE_EXECUTABLE_NAME = "dune";
+  public static final String ESY_EXECUTABLE_NAME = "esy";
+  public static final String WINDOWS_EXECUTABLE_SUFFIX =  ".exe";
+
+  private static final Runnable SHOW_DUNE_NOT_FOUND_NOTIFICATION =
+      () -> Notifications.Bus.notify(new ORNotification("Dune Missing", "Unable to find dune executable in esy PATH.", ERROR));
+
+  private static final Runnable SHOW_ESY_NOT_FOUND_NOTIFICATION =
+      () -> Notifications.Bus.notify(new ORNotification("Esy Missing", "Unable to find esy executable in system PATH.", ERROR));
+
+  private static final Consumer<Exception> SHOW_EXEC_EXCEPTION_NOTIFICATION =
+      (e) -> Notifications.Bus.notify(new ORNotification("Esy Exception", "Failed to execute esy command.\n" + e.getMessage(), ERROR));
+
+  private static final Consumer<Exception> SHOW_DUNE_EXCEPTION_NOTIFICATION =
+      (e) -> Notifications.Bus.notify(new ORNotification("Dune Exception", "Failed to execute dune command.\n" + e.getMessage(), ERROR));
+
+  private static final Log LOG = Log.create("esy");
+
+  public static class Command {
+    public static final String ENV = "env";
+    public static final String PRINT_ENV = "print-env";
+  }
+
+  public static class EnvironmentVariable {
+    public static final String CAML_LD_LIBRARY_PATH = "CAML_LD_LIBRARY_PATH";
+    public static final String DUNE_STORE_ORIG_SOURCE_DIR = "DUNE_STORE_ORIG_SOURCE_DIR";
+    public static final String ESY__ROOT_PACKAGE_CONFIG_PATH = "ESY__ROOT_PACKAGE_CONFIG_PATH";
+    public static final String DUNE_BUILD_DIR = "DUNE_BUILD_DIR";
+    public static final String MAN_PATH = "MAN_PATH";
+    public static final String OCAMLFIND_DESTDIR = "OCAMLFIND_DESTDIR";
+    public static final String OCAMLFIND_LDCONF = "OCAMLFIND_LDCONF";
+    public static final String OCAMLLIB = "OCAMLLIB";
+    public static final String OCAMLPATH = "OCAMLPATH";
+    public static final String PATH = "PATH";
+    public static final Set<String> ALL = ImmutableSet.of(
+        CAML_LD_LIBRARY_PATH,
+        DUNE_STORE_ORIG_SOURCE_DIR,
+        ESY__ROOT_PACKAGE_CONFIG_PATH,
+        CAML_LD_LIBRARY_PATH,
+        DUNE_BUILD_DIR,
+        MAN_PATH,
+        OCAMLFIND_DESTDIR,
+        OCAMLFIND_LDCONF,
+        OCAMLLIB,
+        OCAMLPATH,
+        PATH
+    );
+  }
+
+  private final Project project;
+
+  private final ProcessListener outputListener;
+
+  private final Path workingDir;
+
+  private final Path esyExecutable;
+
+  private final boolean redirectErrors;
+
+  private final AtomicBoolean started;
+
+  @Nullable
+  private KillableColoredProcessHandler processHandler;
+
+  public static EsyProcess getInstance(@NotNull Project project) {
+    return ServiceManager.getService(project, EsyProcess.class);
+  }
+
+  private EsyProcess(@NotNull Project project) {
+    FileSystem fileSystem = FileSystems.getDefault();
+    VirtualFile esyContentRoot = Platform.findOREsyContentRoot(project);
+    Path esyExecutable = findExecutableInPath(ESY_EXECUTABLE_NAME, System.getenv("PATH"))
+        .orElseThrow(() -> {
+          SHOW_ESY_NOT_FOUND_NOTIFICATION.run();
+          return esyNotFoundException();
+        });
+    this.project = project;
+    this.outputListener = new DuneOutputListener(project, this);
+    this.workingDir = fileSystem.getPath(esyContentRoot.getPath());
+    this.esyExecutable = esyExecutable;
+    this.redirectErrors = true;
+    this.started = new AtomicBoolean(false);
+  }
+
+  public boolean isStarted() {
+    return started.get();
+  }
+
+  @Override
+  public boolean start() {
+    if (isStarted()) {
+      LOG.warn("Esy process already started.");
+    }
+    return started.compareAndSet(false, true);
+  }
+
+  @Override
+  public void terminate() {
+    if (!isStarted()) {
+      LOG.warn("Esy process already terminated.");
+      return;
+    }
+    started.set(false);
+  }
+
+  @Override
+  public void startNotify() {
+    if (processHandler != null && !processHandler.isStartNotified()) {
+      try {
+        processHandler.startNotify();
+      } catch (Exception e) {
+        LOG.error("Exception when calling 'startNotify'.", e);
+      }
+    }
+  }
+
+  @Override
+  public ProcessHandler recreate(@NotNull CliType cliType, @Nullable Compiler.ProcessTerminated onProcessTerminated) {
+    killIt();
+
+    Optional<GeneralCommandLine> commandLineOptional = getDuneCommandLine(cliType);
+    if (!commandLineOptional.isPresent()) {
+      SHOW_DUNE_NOT_FOUND_NOTIFICATION.run();
+      return null;
+    }
+
+    GeneralCommandLine commandLine = commandLineOptional.get();
+    try {
+        processHandler = new KillableColoredProcessHandler(commandLine);
+        processHandler.addProcessListener(outputListener);
+        if (onProcessTerminated != null) {
+          processHandler.addProcessListener(new ProcessAdapter() {
+            @Override
+            public void processTerminated(@NotNull ProcessEvent event) {
+              onProcessTerminated.run();
+            }
+          });
+        }
+      return processHandler;
+    } catch (ExecutionException e) {
+      SHOW_DUNE_EXCEPTION_NOTIFICATION.accept(e);
+      LOG.error("Unable to recreate esy process.", e);
+    }
+    return null;
+  }
+
+  public Map<String, String> getEsyEnvironment() {
+    ImmutableMap.Builder<String, String> envBuilder = ImmutableMap.builder();
+    Consumer<String> handleLine = line -> {
+      String[] keyValue = line.split("=");
+      if (EnvironmentVariable.ALL.contains(keyValue[0])) {
+        envBuilder.put(keyValue[0], keyValue[1]);
+      }
+    };
+    exec(Command.ENV, handleLine);
+    return envBuilder.build();
+  }
+
+  public void exec(String command, Consumer<String> handleLine) {
+    GeneralCommandLine commandLine = newEsyCommandLine(command);
+    try {
+      Process process = commandLine.createProcess();
+      InputStreamReader processInputStream = new InputStreamReader(process.getInputStream());
+      BufferedReader reader = new BufferedReader(processInputStream);
+      String line;
+      while ((line = reader.readLine()) != null) {
+        handleLine.accept(line);
+      }
+      int exitCode = process.waitFor();
+      if (exitCode != 0) {
+        LOG.error("Esy command exiting with non-zero code: " + exitCode);
+      }
+    } catch (IOException | InterruptedException | ExecutionException e) {
+      SHOW_EXEC_EXCEPTION_NOTIFICATION.accept(e);
+      LOG.error("Exception while executing esy command.", e);
+    }
+  }
+
+  private void killIt() {
+    if (processHandler == null
+        || processHandler.isProcessTerminating()
+        || processHandler.isProcessTerminated()) {
+      return;
+    }
+    processHandler.killProcess();
+    processHandler = null;
+  }
+
+  private GeneralCommandLine newEsyCommandLine(String command) {
+    GeneralCommandLine commandLine;
+    if (SystemInfo.isWindows) {
+      commandLine = new GeneralCommandLine("cmd.exe");
+      commandLine.addParameter("/c");
+    } else {
+      commandLine = new GeneralCommandLine("sh");
+      commandLine.addParameter("-c");
+    }
+    commandLine.setWorkDirectory(workingDir.toFile());
+    commandLine.setRedirectErrorStream(redirectErrors);
+    commandLine.addParameter(esyExecutable + " " + command); // 'esy + command' must be a single parameter
+    return commandLine;
+  }
+
+  private Optional<GeneralCommandLine> getDuneCommandLine(CliType cliType) {
+    Optional<Path> duneExecutable = findDuneExecutableWithinEsy();
+    if (!duneExecutable.isPresent()) {
+      return Optional.empty();
+    }
+
+    VirtualFile esyContentRoot = Platform.findOREsyContentRoot(project);
+
+    String duneCommand = cliType == CliType.clean ? "clean" : "build"; // @TODO support all actions
+
+    GeneralCommandLine cli = new GeneralCommandLine(duneExecutable.get().toString(), duneCommand);
+    cli.withEnvironment(getEsyEnvironment());
+    cli.setWorkDirectory(esyContentRoot.getPath());
+    cli.setRedirectErrorStream(true);
+    return Optional.of(cli);
+  }
+
+  private Optional<Path> findDuneExecutableWithinEsy() {
+    Map<String, String> esyEnv = getEsyEnvironment();
+    String paths = esyEnv.get(EnvironmentVariable.PATH);
+    if (paths == null) {
+      return Optional.empty();
+    }
+    return findExecutableInPath(DUNE_EXECUTABLE_NAME, paths);
+  }
+
+  private static Optional<Path> findExecutableInPath(String filename, String shellPath) {
+    if (SystemInfo.isWindows) {
+      filename += WINDOWS_EXECUTABLE_SUFFIX;
+    }
+    File exeFile = PathEnvironmentVariableUtil.findInPath(filename, shellPath, null);
+    return exeFile == null ? Optional.empty() : Optional.of(exeFile.toPath());
+  }
+}

--- a/src/com/reason/esy/EsyProcessException.java
+++ b/src/com/reason/esy/EsyProcessException.java
@@ -1,0 +1,39 @@
+package com.reason.esy;
+
+import com.intellij.execution.ExecutionException;
+
+import static com.reason.esy.EsyProcessException.Type.*;
+
+class EsyProcessException extends RuntimeException {
+
+  static enum Type {
+    ESY_EXECUTION_ERROR("Esy command failed."),
+    ESY_NOT_FOUND_IN_PATH("Esy executable not found in PATH.");
+
+    private final String message;
+
+    private Type(String message) {
+      this.message = message;
+    }
+  }
+
+  public static EsyProcessException esyExecutionError() {
+    return new EsyProcessException(ESY_EXECUTION_ERROR);
+  }
+
+  public static EsyProcessException esyExecutionError(ExecutionException e) {
+    return new EsyProcessException(ESY_EXECUTION_ERROR, e);
+  }
+
+  public static EsyProcessException esyNotFoundException() {
+    return new EsyProcessException(ESY_NOT_FOUND_IN_PATH);
+  }
+
+  private EsyProcessException(Type type) {
+    super(type.message);
+  }
+
+  private EsyProcessException(Type type, Throwable cause) {
+    super(type.message, cause);
+  }
+}

--- a/tests/com/reason/esy/EsyProcessTest.java
+++ b/tests/com/reason/esy/EsyProcessTest.java
@@ -1,0 +1,39 @@
+package com.reason.esy;
+
+import com.intellij.openapi.project.Project;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class EsyProcessTest {
+
+  @Mock
+  private Project mockProject;
+
+  private EsyProcess instance;
+
+  @Before
+  public void setUp() throws Exception {
+    initMocks(this);
+    this.instance = EsyProcess.getInstance(mockProject);
+  }
+
+  @Test
+  public void start() {
+    assertFalse(instance.isStarted());
+    instance.start();
+    assertTrue(instance.isStarted());
+  }
+
+  @Test
+  public void terminated() {
+    instance.start();
+    assertTrue(instance.isStarted());
+    instance.terminate();
+    assertFalse(instance.isStarted());
+  }
+}

--- a/tests/com/reason/esy/EsyProcessTest.java
+++ b/tests/com/reason/esy/EsyProcessTest.java
@@ -1,25 +1,16 @@
 package com.reason.esy;
 
-import com.intellij.openapi.project.Project;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.MockitoAnnotations.initMocks;
-
-public class EsyProcessTest {
-
-  @Mock
-  private Project mockProject;
+public class EsyProcessTest extends BasePlatformTestCase {
 
   private EsyProcess instance;
 
   @Before
   public void setUp() throws Exception {
-    initMocks(this);
-    this.instance = EsyProcess.getInstance(mockProject);
+    this.instance = EsyProcess.getInstance(getProject());
   }
 
   @Test


### PR DESCRIPTION
This PR enables dune to run within esy sandbox environments. Currently, the plugin fails to find the dune executable as it looks for it installed within the global ocaml install. 

Esy stores all executables (including dune) within a sandbox environment (~/.esy). This sandbox environment is available via a set of environment variables set by the esy executable. These variables can be found with either `esy env` or `esy print-env`. 

If esy is configured, these environment variables are now added to the process that calls dune. 