### PR TITLE
default m_refmtOnSave to false

### DIFF
--- a/src/com/reason/ide/settings/ReasonSettings.java
+++ b/src/com/reason/ide/settings/ReasonSettings.java
@@ -15,7 +15,7 @@ public class ReasonSettings implements PersistentStateComponent<ReasonSettings.R
 
     private Project m_project;
     private boolean m_enabled = true;
-    private boolean m_refmtOnSave = true;
+    private boolean m_refmtOnSave = false;
     @NotNull
     private String m_location = "";
     @NotNull
@@ -118,7 +118,7 @@ public class ReasonSettings implements PersistentStateComponent<ReasonSettings.R
     @SuppressWarnings("WeakerAccess")
     public static class ReasonSettingsState {
         public boolean enabled = true;
-        public boolean refmtOnSave = true;
+        public boolean refmtOnSave = false;
 
         @NotNull
         public String location = "";


### PR DESCRIPTION
I propose to disable refmt on save by default because of annoying bug with shared Intellij settings between projects. It also makes working with undo/redo very cumbersome.

Issues:
https://github.com/reasonml-editor/reasonml-idea-plugin/issues/86
https://github.com/reasonml-editor/reasonml-idea-plugin/issues/69