### PR TITLE
ORModuleManager now searches for all dune files.

### DIFF
--- a/src/com/reason/dune/DuneConstants.java
+++ b/src/com/reason/dune/DuneConstants.java
@@ -1,0 +1,13 @@
+package com.reason.dune;
+
+public class DuneConstants {
+
+    public static final String DUNE_PROJECT_FILENAME = "dune-project";
+
+    public static final String DUNE_FILENAME = "dune";
+
+    public static final String LEGACY_JBUILDER_FILENAME = "jbuilder";
+
+    private DuneConstants() {}
+
+}

--- a/src/com/reason/dune/DuneConstants.java
+++ b/src/com/reason/dune/DuneConstants.java
@@ -6,7 +6,7 @@ public class DuneConstants {
 
     public static final String DUNE_FILENAME = "dune";
 
-    public static final String LEGACY_JBUILDER_FILENAME = "jbuilder";
+    public static final String LEGACY_JBUILDER_FILENAME = "jbuild";
 
     private DuneConstants() {}
 

--- a/src/com/reason/ide/ORModuleManager.java
+++ b/src/com/reason/ide/ORModuleManager.java
@@ -67,7 +67,7 @@ public class ORModuleManager {
         if (foundFile != null) {
             return Optional.of(foundFile);
         }
-        // finally, a "jbuilder" file...
+        // finally, a "jbuild" file...
         foundFile = foundFiles.get(LEGACY_JBUILDER_FILENAME);
         if (foundFile != null) {
             return Optional.of(foundFile);

--- a/src/com/reason/ide/ORModuleManager.java
+++ b/src/com/reason/ide/ORModuleManager.java
@@ -50,6 +50,7 @@ public class ORModuleManager {
         return findFileInModule(BsConfigJsonFileType.getDefaultFilename(), module);
     }
 
+    /* searches module for files named "dune-project", then "dune", and lastly "jbuild" */
     public static Optional<VirtualFile> findDuneConfigurationFile(@NotNull Module module) {
         Map<String, VirtualFile> foundFiles = findFilesInModule(DUNE_PROJECT_FILES, module).stream()
                 .collect(Collectors.toMap(VirtualFile::getName, Function.identity()));

--- a/src/com/reason/ide/ORModuleManager.java
+++ b/src/com/reason/ide/ORModuleManager.java
@@ -1,5 +1,6 @@
 package com.reason.ide;
 
+import com.google.common.collect.ImmutableSet;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
@@ -8,22 +9,26 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.reason.Log;
 import com.reason.esy.EsyPackageJson;
 import com.reason.ide.files.BsConfigJsonFileType;
-import com.reason.ide.files.DuneFileType;
 import com.reason.ide.files.EsyPackageJsonFileType;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Iterator;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static com.reason.dune.DuneConstants.*;
 
 /**
  * Identifies and retrieves modules by framework type (Bs, Esy, Dune).
  * Prefer this class to access {@link ModuleManager} directly.
  */
 public class ORModuleManager {
+
+    private static final Set<String> DUNE_PROJECT_FILES = ImmutableSet.of(
+            DUNE_FILENAME,
+            DUNE_PROJECT_FILENAME,
+            LEGACY_JBUILDER_FILENAME);
 
     private static final Log LOG = Log.create("manager.module");
 
@@ -46,7 +51,30 @@ public class ORModuleManager {
     }
 
     public static Optional<VirtualFile> findDuneConfigurationFile(@NotNull Module module) {
-        return findFileInModule(DuneFileType.getDefaultFilename(), module);
+        Map<String, VirtualFile> foundFiles = findFilesInModule(DUNE_PROJECT_FILES, module).stream()
+                .collect(Collectors.toMap(VirtualFile::getName, Function.identity()));
+        // first, if no matches were found, return empty...
+        if (foundFiles.isEmpty()) {
+            return Optional.empty();
+        }
+        // then let's see if "dune-project" was found...
+        VirtualFile foundFile = foundFiles.get(DUNE_PROJECT_FILENAME);
+        if (foundFile != null) {
+            return Optional.of(foundFile);
+        }
+        // next, let's check for a "dune" file...
+        foundFile = foundFiles.get(DUNE_FILENAME);
+        if (foundFile != null) {
+            return Optional.of(foundFile);
+        }
+        // finally, a "jbuilder" file...
+        foundFile = foundFiles.get(LEGACY_JBUILDER_FILENAME);
+        if (foundFile != null) {
+            return Optional.of(foundFile);
+        }
+        // if we get here, something went wrong...
+        LOG.warn("Something went wrong. Dune file might have been removed while searching?");
+        return Optional.empty();
     }
 
     public static Optional<VirtualFile> findEsyConfigurationFile(@NotNull Module module) {
@@ -146,5 +174,21 @@ public class ORModuleManager {
             }
         }
         return Optional.empty();
+    }
+
+    private static Set<VirtualFile> findFilesInModule(@NotNull Set<String> filenames, @NotNull Module module) {
+        Set<VirtualFile> foundFiles = new HashSet<>(filenames.size());
+        Set<String> remainingFilenames = new HashSet<>(filenames);
+        for (VirtualFile contentRoot : ModuleRootManager.getInstance(module).getContentRoots()) {
+            for (Iterator<String> iterator = remainingFilenames.iterator(); iterator.hasNext();) {
+                String filename = iterator.next();
+                VirtualFile file = contentRoot.findChild(filename);
+                if (file != null) {
+                    foundFiles.add(file);
+                    iterator.remove();
+                }
+            }
+        }
+        return foundFiles;
     }
 }

--- a/src/com/reason/ide/files/DuneFileType.java
+++ b/src/com/reason/ide/files/DuneFileType.java
@@ -11,12 +11,14 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import java.util.Set;
 
+import static com.reason.dune.DuneConstants.*;
+
 public class DuneFileType extends LanguageFileType {
 
     public static final FileType INSTANCE = new DuneFileType();
 
     public static Set<String> getDefaultFilenames() {
-        return ImmutableSet.of("dune", "dune-project", "jbuild");
+        return ImmutableSet.of(DUNE_FILENAME, DUNE_PROJECT_FILENAME, LEGACY_JBUILDER_FILENAME);
     }
 
     private DuneFileType() {


### PR DESCRIPTION
Fixed ORModuleManager so it searches for all dune project files (dune-project, dune, jbuild).

See commit messages below.

Note: this branch is blocked until pooch/dune-file-type-refactor is merged.