### PR TITLE
Temporary fix. Always enable bucklescript window.

### DIFF
--- a/src/com/reason/ide/ORModuleManager.java
+++ b/src/com/reason/ide/ORModuleManager.java
@@ -167,6 +167,7 @@ public class ORModuleManager {
         return iterator.hasNext() ? Optional.of(iterator.next()) : Optional.empty();
     }
 
+    /* @TODO add support for nested configuration files, i.e. recursive search here */
     private static Optional<VirtualFile> findFileInModule(@NotNull String filename, @NotNull Module module) {
         for (VirtualFile contentRoot : ModuleRootManager.getInstance(module).getContentRoots()) {
             VirtualFile file = contentRoot.findChild(filename);

--- a/src/com/reason/ide/console/BsToolWindowFactory.java
+++ b/src/com/reason/ide/console/BsToolWindowFactory.java
@@ -10,7 +10,6 @@ import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
-import com.reason.Platform;
 import icons.ORIcons;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -44,7 +43,8 @@ public class BsToolWindowFactory extends ORToolWindowFactory {
 
     @Override
     public boolean shouldBeAvailable(@NotNull Project project) {
-        return Platform.findProjectBsconfig(project) != null;
+        // @TODO TEMPORARY - replace with ORModuleManager::findFirstBsModule
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Please see code comments below.

This fix will always display the bucklescript window. This fixes an issue where nested bsconfig.json files are not recognized (monorepos).

This is temporary. A better fix will be applied to BsToolWindowFactory.shouldBeAvailable to use a revised version of ORModuleManager::findFirstBsContentRoot that checks for nested configs.