### PR TITLE
Sort Found Configuration Files by Depth + Tests

### DIFF
--- a/jps-plugin/src/com/reason/Platform.java
+++ b/jps-plugin/src/com/reason/Platform.java
@@ -24,9 +24,7 @@ public class Platform {
 
     public static final String LOCAL_BS_PLATFORM = "/node_modules/bs-platform";
     public static final String LOCAL_NODE_MODULES_BIN = "/node_modules/.bin";
-    public static final String DUNE_NAME = "dune-project";
     public static final String PACKAGE_JSON_NAME = "package.json";
-    public static final String ESY_PROJECT_IDENTIFIER = "_esy";
     public static final String BSCONFIG_JSON_NAME = "bsconfig.json";
     public static final Charset UTF8 = StandardCharsets.UTF_8;
 
@@ -79,6 +77,9 @@ public class Platform {
         return rootContents;
     }
 
+    /**
+     * @deprecated replace usages with ORProjectManager::findContentRoots which returns ALL potential roots.
+     */
     public static VirtualFile findContentRootFor(@NotNull Project project, @NotNull String filename) {
         Map<Module, VirtualFile> rootContents = findContentRootsFor(project, filename);
 
@@ -97,32 +98,20 @@ public class Platform {
         }
     }
 
-    public static VirtualFile findORDuneContentRoot(@NotNull Project project) {
-        return findContentRootFor(project, DUNE_NAME);
-    }
 
-    public static VirtualFile findOREsyContentRoot(@NotNull Project project) {
-        return findContentRootFor(project, ESY_PROJECT_IDENTIFIER);
-    }
-
+    /**
+     * Project Special finder that iterate through parents until a bsConfig.json is found.
+     * This is always needed, we can't use module itself.
+     * @deprecated move this logic out of jps-plugin. Break it up into 2 separate methods:
+     *  1. ORFileManager::findFirstAncestor
+     *  2. ORProjectManager::findAncestorBsConfig
+     *  This method currently used findContentRootsFor which is deprecated as a project might have multiple
+     *  content roots.
+     */
     @Nullable
-    public static VirtualFile findORPackageJsonContentRoot(@NotNull Project project) {
-        return findContentRootFor(project, PACKAGE_JSON_NAME);
-    }
-
-    @Nullable
-    public static VirtualFile findProjectBsconfig(@NotNull Project project) {
-        // @TODO use `BsConfigFile.isBsConfig(file)`
-        VirtualFile contentRoot = findORPackageJsonContentRoot(project);
-        return contentRoot == null ? null : contentRoot.findChild(BSCONFIG_JSON_NAME);
-    }
-
-    // Special finder that iterate through parents until a bsConfig.json is found.
-    // This is always needed, we can't use module itself
-
-    @Nullable
+    @Deprecated
     public static VirtualFile findAncestorBsconfig(@NotNull Project project, @NotNull VirtualFile sourceFile) {
-        VirtualFile contentRoot = findProjectBsconfig(project);
+        VirtualFile contentRoot = findContentRootFor(project, BSCONFIG_JSON_NAME);
         if (sourceFile.equals(contentRoot)) {
             return sourceFile;
         }
@@ -149,15 +138,25 @@ public class Platform {
         return child;
     }
 
+    /**
+     * @deprecated see {@link Platform::findAncestorBsconfig}
+     */
+    @Deprecated
     public static VirtualFile findAncestorContentRoot(Project project, VirtualFile file) {
         VirtualFile bsConfig = findAncestorBsconfig(project, file);
         return bsConfig == null ? null : bsConfig.getParent();
     }
 
+    /**
+     * @deprecated Move this out of jps-plugin and replace implementation with ORProjectManager.
+     *             This incorrectly assumes that the project is a BuckleScript project which might
+     *             not be the case. Could be Dune, Esy, mono-repo, etc.
+     */
     @NotNull
+    @Deprecated
     public static String removeProjectDir(@NotNull Project project, @NotNull String path) {
         try {
-            VirtualFile baseRoot = Platform.findORPackageJsonContentRoot(project);
+            VirtualFile baseRoot = findContentRootFor(project, PACKAGE_JSON_NAME);
             if (baseRoot == null) {
                 return path;
             }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -264,8 +264,8 @@
 
         <applicationService serviceImplementation="com.reason.ide.ORCompilerManager"/>
         <projectService serviceImplementation="com.reason.bs.BsProcess"/>
-        <projectService serviceInterface="com.reason.bs.Bucklescript"
-                        serviceImplementation="com.reason.bs.BucklescriptImpl"/>
+        <projectService serviceInterface="com.reason.bs.BsCompiler"
+                        serviceImplementation="com.reason.bs.BsCompilerImpl"/>
 
         <!--
          | Insight

--- a/src/com/reason/Compiler.java
+++ b/src/com/reason/Compiler.java
@@ -6,6 +6,9 @@ import com.reason.ide.console.CliType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+import java.util.Set;
+
 public interface Compiler {
 
     @FunctionalInterface
@@ -13,8 +16,9 @@ public interface Compiler {
         void run();
     }
 
-    @Nullable
-    VirtualFile findContentRoot(@NotNull Project project);
+    Optional<VirtualFile> findFirstContentRoot(@NotNull Project project);
+
+    Set<VirtualFile> findContentRoots(@NotNull Project project);
 
     void refresh(@NotNull VirtualFile configFile);
 

--- a/src/com/reason/bs/BsCompiler.java
+++ b/src/com/reason/bs/BsCompiler.java
@@ -1,6 +1,5 @@
 package com.reason.bs;
 
-import java.util.*;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -8,7 +7,7 @@ import com.reason.Compiler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public interface Bucklescript extends Compiler {
+public interface BsCompiler extends Compiler {
 
     boolean isDependency(@Nullable VirtualFile file);
 

--- a/src/com/reason/bs/BsCompilerImpl.java
+++ b/src/com/reason/bs/BsCompilerImpl.java
@@ -19,6 +19,7 @@ import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.content.Content;
 import com.reason.*;
 import com.reason.hints.InsightManager;
+import com.reason.ide.ORProjectManager;
 import com.reason.ide.console.BsToolWindowFactory;
 import com.reason.ide.console.CliType;
 import com.reason.ide.settings.ReasonSettings;
@@ -28,8 +29,10 @@ import org.jetbrains.coverage.gnu.trove.THashMap;
 
 import javax.swing.*;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
-public class BucklescriptImpl implements Bucklescript {
+public class BsCompilerImpl implements BsCompiler {
 
     @NotNull
     private final Project m_project;
@@ -38,7 +41,7 @@ public class BucklescriptImpl implements Bucklescript {
     @Nullable
     private Boolean m_disabled = null; // Never call directly, use isDisabled()
 
-    private BucklescriptImpl(@NotNull Project project) {
+    private BsCompilerImpl(@NotNull Project project) {
         m_project = project;
     }
 
@@ -53,11 +56,15 @@ public class BucklescriptImpl implements Bucklescript {
         return "";
     }
 
-    //region Compiler
-    @Nullable
     @Override
-    public VirtualFile findContentRoot(@NotNull Project project) {
-        return Platform.findORPackageJsonContentRoot(project);
+    @Deprecated
+    public Optional<VirtualFile> findFirstContentRoot(@NotNull Project project) {
+        return ORProjectManager.findFirstEsyContentRoot(project);
+    }
+
+    @Override
+    public Set<VirtualFile> findContentRoots(@NotNull Project project) {
+        return ORProjectManager.findBsContentRoots(project);
     }
 
     @Override

--- a/src/com/reason/bs/BsConstants.java
+++ b/src/com/reason/bs/BsConstants.java
@@ -2,6 +2,8 @@ package com.reason.bs;
 
 public class BsConstants {
 
+    public static final String BS_CONFIG_FILENAME = "bsconfig.json";
+
     public static final String BS_JS_FILE_EXTENSION = "bs.js";
 
 }

--- a/src/com/reason/bs/BsProcess.java
+++ b/src/com/reason/bs/BsProcess.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.reason.Compiler;
 import com.reason.*;
+import com.reason.ide.ORProjectManager;
 import com.reason.ide.console.CliType;
 import com.reason.ide.settings.ReasonSettings;
 import org.jetbrains.annotations.NotNull;
@@ -41,8 +42,10 @@ public final class BsProcess implements CompilerProcess {
     private final AtomicBoolean m_restartNeeded = new AtomicBoolean(false);
 
     public BsProcess(@NotNull Project project) {
-        m_project = project;
-        create(Platform.findProjectBsconfig(project), CliType.Bs.MAKE, null);
+        // no file is active yet, default working directory to the top-level bsconfig.json file
+        VirtualFile firstBsContentRoot = ORProjectManager.findFirstBsConfigurationFile(project).orElse(null);
+        create(firstBsContentRoot, CliType.Bs.MAKE, null);
+        this.m_project = project;
     }
 
     // Wait for the tool window to be ready before starting the process

--- a/src/com/reason/dune/DuneCompiler.java
+++ b/src/com/reason/dune/DuneCompiler.java
@@ -13,9 +13,12 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.content.Content;
 import com.reason.Compiler;
-import com.reason.*;
+import com.reason.CompilerProcess;
+import com.reason.CompilerType;
+import com.reason.ProcessFinishedListener;
 import com.reason.esy.EsyProcess;
 import com.reason.hints.InsightManager;
+import com.reason.ide.ORProjectManager;
 import com.reason.ide.console.CliType;
 import com.reason.ide.console.DuneToolWindowFactory;
 import com.reason.ide.facet.DuneFacet;
@@ -23,6 +26,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.util.Optional;
+import java.util.Set;
 
 public class DuneCompiler implements Compiler {
 
@@ -42,10 +47,14 @@ public class DuneCompiler implements Compiler {
         return CompilerType.DUNE;
     }
 
-    @Nullable
     @Override
-    public VirtualFile findContentRoot(@NotNull Project project) {
-        return Platform.findORDuneContentRoot(project);
+    public Optional<VirtualFile> findFirstContentRoot(@NotNull Project project) {
+        return ORProjectManager.findFirstDuneContentRoot(project);
+    }
+
+    @Override
+    public Set<VirtualFile> findContentRoots(@NotNull Project project) {
+        return ORProjectManager.findDuneContentRoots(project);
     }
 
     @Override

--- a/src/com/reason/dune/DuneProcess.java
+++ b/src/com/reason/dune/DuneProcess.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.reason.Compiler;
 import com.reason.*;
+import com.reason.ide.ORProjectManager;
 import com.reason.ide.console.CliType;
 import com.reason.sdk.OCamlSdkType;
 import org.jetbrains.annotations.NotNull;
@@ -19,6 +20,7 @@ import java.io.File;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.intellij.notification.NotificationListener.URL_OPENING_LISTENER;
@@ -102,8 +104,8 @@ public final class DuneProcess implements CompilerProcess {
         }
         assert odk.getHomePath() != null;
 
-        VirtualFile baseRoot = Platform.findORDuneContentRoot(m_project);
-        if (baseRoot == null) {
+        Optional<VirtualFile> baseRoot = ORProjectManager.findFirstDuneContentRoot(m_project);
+        if (!baseRoot.isPresent()) {
             return null;
         }
 
@@ -134,7 +136,7 @@ public final class DuneProcess implements CompilerProcess {
         cli.withEnvironment("PATH", ocamlPath + File.pathSeparator + environment.get("PATH"));
         cli.withEnvironment("OCAMLLIB", fileSystem.getPath(odk.getHomePath(), "lib", "ocaml").toString());
         cli.withEnvironment("CAML_LD_LIBRARY_PATH", libPath);
-        cli.setWorkDirectory(baseRoot.getPath());
+        cli.setWorkDirectory(baseRoot.get().getPath());
         cli.setRedirectErrorStream(true);
 
         return cli;

--- a/src/com/reason/esy/EsyConstants.java
+++ b/src/com/reason/esy/EsyConstants.java
@@ -1,0 +1,9 @@
+package com.reason.esy;
+
+public class EsyConstants {
+
+    public static final String ESY_CONFIG_FILENAME = "package.json";
+
+    private EsyConstants() {}
+
+}

--- a/src/com/reason/hints/InsightUpdateQueue.java
+++ b/src/com/reason/hints/InsightUpdateQueue.java
@@ -72,7 +72,7 @@ public class InsightUpdateQueue extends MergingUpdateQueue {
     public void initConfig(@NotNull Project project) {
         LOG.debug("Refresh bsconfig");
 
-        Bucklescript bucklescript = ServiceManager.getService(project, Bucklescript.class);
+        BsCompiler bucklescript = ServiceManager.getService(project, BsCompiler.class);
 
         // Read build.ninja
         m_ninja = bucklescript.readNinjaBuild(m_contentRoot);

--- a/src/com/reason/ide/ORCompilerManager.java
+++ b/src/com/reason/ide/ORCompilerManager.java
@@ -9,15 +9,19 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.reason.Compiler;
-import com.reason.Log;
 import com.reason.CompilerType;
+import com.reason.Log;
 import com.reason.ORNotification;
-import com.reason.bs.Bucklescript;
+import com.reason.bs.BsCompiler;
 import com.reason.dune.DuneCompiler;
 import com.reason.ide.console.CliType;
 import com.reason.ide.facet.DuneFacet;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 import static com.intellij.notification.NotificationListener.URL_OPENING_LISTENER;
 import static com.intellij.notification.NotificationType.ERROR;
@@ -27,10 +31,14 @@ public class ORCompilerManager {
     private static final Log LOG = Log.create("manager.compiler");
 
     private static final Compiler DUMMY_COMPILER = new Compiler() {
-        @Nullable
         @Override
-        public VirtualFile findContentRoot(@NotNull Project project) {
-            return null;
+        public Optional<VirtualFile> findFirstContentRoot(@NotNull Project project) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Set<VirtualFile> findContentRoots(@NotNull Project project) {
+            return Collections.emptySet();
         }
 
         @Override
@@ -68,6 +76,6 @@ public class ORCompilerManager {
             }
         }
 
-        return ServiceManager.getService(project, Bucklescript.class);
+        return ServiceManager.getService(project, BsCompiler.class);
     }
 }

--- a/src/com/reason/ide/ORFileManager.java
+++ b/src/com/reason/ide/ORFileManager.java
@@ -10,7 +10,7 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.reason.Joiner;
 import com.reason.Log;
 import com.reason.StringUtil;
-import com.reason.bs.Bucklescript;
+import com.reason.bs.BsCompiler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -51,7 +51,7 @@ public class ORFileManager {
     @NotNull
     public static String toRelativeSourceName(@NotNull Project project, @NotNull VirtualFile sourceFile, @NotNull Path relativePath) {
         String sourcePath = relativePath.toString();
-        String namespace = ServiceManager.getService(project, Bucklescript.class).getNamespace(sourceFile);
+        String namespace = ServiceManager.getService(project, BsCompiler.class).getNamespace(sourceFile);
         if (!namespace.isEmpty()) {
             sourcePath = sourcePath.replace("-" + StringUtil.toFirstUpper(namespace), "");
         }

--- a/src/com/reason/ide/ORProjectManager.java
+++ b/src/com/reason/ide/ORProjectManager.java
@@ -54,6 +54,10 @@ public class ORProjectManager {
         return !findEsyConfigurationFiles(project).isEmpty();
     }
 
+    public static Optional<VirtualFile> findFirstBsConfigurationFile(@NotNull Project project) {
+        return findFirst(findBsConfigurationFiles(project));
+    }
+
     public static Set<VirtualFile> findBsConfigurationFiles(@NotNull Project project) {
         return findFilesInProject(BsConfigJsonFileType.getDefaultFilename(), project);
     }
@@ -70,7 +74,8 @@ public class ORProjectManager {
                 .collect(Collectors.toSet());
     }
 
-    public static Set<VirtualFile> findBsContentRoots(@NotNull Project project) {
+     // * @TODO this MUST be sorted. should return root config first
+    public static LinkedHashSet<VirtualFile> findBsContentRoots(@NotNull Project project) {
         return findContentRoots(project, ORProjectManager::findBsConfigurationFiles);
     }
 
@@ -95,30 +100,16 @@ public class ORProjectManager {
         return new HashSet<>(virtualFilesByName);
     }
 
-    /**
-     * @deprecated there could be more than 1 BuckleScript configurations in a project.
-     */
-    @Deprecated
+     // @TODO this should be sorted, ancestors -> children
     public static Optional<VirtualFile> findFirstBsContentRoot(@NotNull Project project) {
-        LOG.warn("Using deprecated method 'findFirstBsContentRoot'.");
         return findFirst(findBsContentRoots(project));
     }
 
-    /**
-     * @deprecated there could be more than 1 Dune configurations in a project.
-     */
-    @Deprecated
     public static Optional<VirtualFile> findFirstDuneContentRoot(@NotNull Project project) {
-        LOG.warn("Using deprecated method 'findFirstDuneContentRoot'.");
         return findFirst(findDuneContentRoots(project));
     }
 
-    /**
-     * @deprecated there could be more than 1 Esy configurations in a project.
-     */
-    @Deprecated
     public static Optional<VirtualFile> findFirstEsyContentRoot(@NotNull Project project) {
-        LOG.warn("Using deprecated method 'findFirstEsyContentRoot'.");
         return findFirst(findEsyContentRoots(project));
     }
 

--- a/src/com/reason/ide/actions/ConvertAction.java
+++ b/src/com/reason/ide/actions/ConvertAction.java
@@ -21,7 +21,7 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
-import com.reason.bs.Bucklescript;
+import com.reason.bs.BsCompiler;
 import com.reason.ORNotification;
 import com.reason.ide.files.FileHelper;
 
@@ -40,7 +40,7 @@ public class ConvertAction extends AnAction {
     }
 
     protected void apply(@NotNull Project project, @NotNull PsiFile file, boolean isNewFile) {
-        Bucklescript bucklescript = ServiceManager.getService(project, Bucklescript.class);
+        BsCompiler bucklescript = ServiceManager.getService(project, BsCompiler.class);
         FileType fileType = file.getFileType();
 
         final Document document = PsiDocumentManager.getInstance(project).getDocument(file);

--- a/src/com/reason/ide/actions/ReformatAction.java
+++ b/src/com/reason/ide/actions/ReformatAction.java
@@ -7,7 +7,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
-import com.reason.bs.Bucklescript;
+import com.reason.bs.BsCompiler;
 import com.reason.ide.files.FileHelper;
 import com.reason.ide.format.ReformatUtil;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +25,7 @@ public class ReformatAction extends AnAction {
                 Document document = PsiDocumentManager.getInstance(project).getCachedDocument(file);
                 if (document != null) {
                     ServiceManager.
-                            getService(project, Bucklescript.class).
+                            getService(project, BsCompiler.class).
                             refmt(file.getVirtualFile(), FileHelper.isInterface(file.getFileType()), format, document);
                 }
             }

--- a/src/com/reason/ide/console/CompilerAction.java
+++ b/src/com/reason/ide/console/CompilerAction.java
@@ -13,11 +13,12 @@ import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import com.reason.Compiler;
 import com.reason.CompilerType;
-import com.reason.bs.Bucklescript;
+import com.reason.bs.BsCompiler;
 import com.reason.ide.ORCompilerManager;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import java.util.Optional;
 
 abstract class CompilerAction extends DumbAwareAction {
 
@@ -33,14 +34,16 @@ abstract class CompilerAction extends DumbAwareAction {
         // Try to detect the current active editor
         Editor editor = FileEditorManager.getInstance(project).getSelectedTextEditor();
         if (editor == null) {
-            ConsoleView console = ServiceManager.getService(project, Bucklescript.class).getBsbConsole();
+            ConsoleView console = ServiceManager.getService(project, BsCompiler.class).getBsbConsole();
             if (console != null) {
-                VirtualFile baseDir = compiler.findContentRoot(project);
-                if (baseDir == null) {
+                Optional<VirtualFile> baseDirectoryOptional = compiler.findFirstContentRoot(project);
+                if (!baseDirectoryOptional.isPresent()) {
                     console.print("Can't find content root\n", ConsoleViewContentType.NORMAL_OUTPUT);
                 } else {
-                    console.print("No active text editor found, using root directory " + baseDir.getPath() + "\n", ConsoleViewContentType.NORMAL_OUTPUT);
-                    compiler.run(baseDir, cliType, null);
+                    VirtualFile baseDirectory = baseDirectoryOptional.get();
+                    console.print("No active text editor found, using root directory " +
+                                    baseDirectory.getPath() + "\n", ConsoleViewContentType.NORMAL_OUTPUT);
+                    compiler.run(baseDirectory, cliType, null);
                 }
             }
         } else {

--- a/src/com/reason/ide/editors/CmtXmlComponent.java
+++ b/src/com/reason/ide/editors/CmtXmlComponent.java
@@ -2,21 +2,15 @@ package com.reason.ide.editors;
 
 import com.intellij.ide.highlighter.HtmlFileType;
 import com.intellij.lang.xhtml.XHTMLLanguage;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.EditorFactory;
-import com.intellij.openapi.fileTypes.PlainTextFileType;
-import com.intellij.openapi.fileTypes.PlainTextLanguage;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiFileFactory;
 import com.intellij.ui.components.JBTabbedPane;
 import com.intellij.util.ui.components.BorderLayoutPanel;
-import com.reason.bs.Bucklescript;
-import com.reason.bs.BucklescriptImpl;
-import com.reason.hints.InsightManager;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.event.ChangeEvent;

--- a/src/com/reason/ide/files/EsyPackageJsonFileType.java
+++ b/src/com/reason/ide/files/EsyPackageJsonFileType.java
@@ -1,17 +1,20 @@
 package com.reason.ide.files;
 
-import javax.swing.*;
-import org.jetbrains.annotations.Nullable;
 import com.intellij.json.JsonFileType;
 import com.intellij.openapi.fileTypes.FileType;
 import icons.ORIcons;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+import static com.reason.esy.EsyConstants.ESY_CONFIG_FILENAME;
 
 public class EsyPackageJsonFileType extends JsonFileType {
 
     public static final FileType INSTANCE = new EsyPackageJsonFileType();
 
     public static String getDefaultFilename() {
-        return "package.json";
+        return ESY_CONFIG_FILENAME;
     }
 
     private EsyPackageJsonFileType() {

--- a/src/com/reason/ide/format/ReformatOnSave.java
+++ b/src/com/reason/ide/format/ReformatOnSave.java
@@ -8,7 +8,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
-import com.reason.bs.Bucklescript;
+import com.reason.bs.BsCompiler;
 import com.reason.ide.files.FileHelper;
 import com.reason.ide.settings.ReasonSettings;
 
@@ -30,7 +30,7 @@ public class ReformatOnSave {
                 String format = ReformatUtil.getFormat(file);
                 if (format != null) {
                     ServiceManager.
-                            getService(project, Bucklescript.class).
+                            getService(project, BsCompiler.class).
                             refmt(virtualFile, FileHelper.isInterface(file.getFileType()), format, document);
                 }
             }

--- a/src/com/reason/ide/js/ORJsLibraryManager.java
+++ b/src/com/reason/ide/js/ORJsLibraryManager.java
@@ -11,7 +11,6 @@ import com.intellij.openapi.vfs.pointers.VirtualFilePointerListener;
 import com.intellij.openapi.vfs.pointers.VirtualFilePointerManager;
 import com.intellij.webcore.libraries.ScriptingLibraryModel;
 import com.reason.Log;
-import com.reason.Platform;
 import com.reason.bs.BsConfig;
 import com.reason.bs.BsConfigReader;
 import com.reason.ide.ORProjectManager;
@@ -35,7 +34,8 @@ public class ORJsLibraryManager implements StartupActivity, DumbAware {
         JSLibraryManager jsLibraryManager = JSLibraryManager.getInstance(project);
 
         Optional<VirtualFile> bsConfigFileOptional = ORProjectManager.findFirstBsConfigurationFile(project);
-        if (bsConfigFile != null) {
+        if (bsConfigFileOptional.isPresent()) {
+            VirtualFile bsConfigFile = bsConfigFileOptional.get();
             String baseDir = "file://" + bsConfigFile.getParent().getPath() + "/node_modules/";
             List<VirtualFile> sources = new ArrayList<>(readBsConfigDependencies(project, baseDir, bsConfigFile));
 

--- a/src/com/reason/ide/js/ORJsLibraryManager.java
+++ b/src/com/reason/ide/js/ORJsLibraryManager.java
@@ -14,10 +14,12 @@ import com.reason.Log;
 import com.reason.Platform;
 import com.reason.bs.BsConfig;
 import com.reason.bs.BsConfigReader;
+import com.reason.ide.ORProjectManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static com.intellij.openapi.vfs.VirtualFile.EMPTY_ARRAY;
 import static com.intellij.util.ArrayUtilRt.EMPTY_STRING_ARRAY;
@@ -32,7 +34,7 @@ public class ORJsLibraryManager implements StartupActivity, DumbAware {
     public void runActivity(@NotNull Project project) {
         JSLibraryManager jsLibraryManager = JSLibraryManager.getInstance(project);
 
-        VirtualFile bsConfigFile = Platform.findProjectBsconfig(project);
+        Optional<VirtualFile> bsConfigFileOptional = ORProjectManager.findFirstBsConfigurationFile(project);
         if (bsConfigFile != null) {
             String baseDir = "file://" + bsConfigFile.getParent().getPath() + "/node_modules/";
             List<VirtualFile> sources = new ArrayList<>(readBsConfigDependencies(project, baseDir, bsConfigFile));

--- a/src/com/reason/ide/search/PsiFinder.java
+++ b/src/com/reason/ide/search/PsiFinder.java
@@ -16,7 +16,7 @@ import com.intellij.util.containers.ArrayListSet;
 import com.intellij.util.indexing.FileBasedIndex;
 import com.reason.Joiner;
 import com.reason.Log;
-import com.reason.bs.Bucklescript;
+import com.reason.bs.BsCompiler;
 import com.reason.ide.files.FileBase;
 import com.reason.ide.files.FileHelper;
 import com.reason.ide.files.RmlFileType;
@@ -87,7 +87,7 @@ public final class PsiFinder {
 
         PartitionedModules(@NotNull Project project, @Nullable Collection<PsiModule> modules, @Nullable ModuleFilter<PsiModule> filter) {
             if (modules != null) {
-                Bucklescript bucklescript = ServiceManager.getService(project, Bucklescript.class);
+                BsCompiler bucklescript = ServiceManager.getService(project, BsCompiler.class);
 
                 for (PsiModule module : modules) {
                     PsiModule realModule = module instanceof PsiFakeModule ? (FileBase) module.getContainingFile() : module;
@@ -164,7 +164,7 @@ public final class PsiFinder {
 
         PsiModule module = modules.iterator().next();
         return ServiceManager.
-                getService(m_project, Bucklescript.class).
+                getService(m_project, BsCompiler.class).
                 isDependency(module.getContainingFile().getVirtualFile()) ? module : null;
     }
 
@@ -177,7 +177,7 @@ public final class PsiFinder {
 
         Set<PsiModule> result = new HashSet<>();
 
-        Bucklescript bucklescript = ServiceManager.getService(m_project, Bucklescript.class);
+        BsCompiler bucklescript = ServiceManager.getService(m_project, BsCompiler.class);
 
         ModuleComponentIndex componentIndex = ModuleComponentIndex.getInstance();
         ModuleIndex moduleIndex = ModuleIndex.getInstance();

--- a/src/com/reason/ide/search/index/NamespaceIndex.java
+++ b/src/com/reason/ide/search/index/NamespaceIndex.java
@@ -1,25 +1,24 @@
 package com.reason.ide.search.index;
 
-import java.util.*;
-import org.jetbrains.annotations.NotNull;
 import com.intellij.json.JsonFileType;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.util.indexing.DataIndexer;
-import com.intellij.util.indexing.FileBasedIndex;
-import com.intellij.util.indexing.FileContent;
-import com.intellij.util.indexing.ID;
-import com.intellij.util.indexing.ScalarIndexExtension;
+import com.intellij.util.indexing.*;
 import com.intellij.util.io.EnumeratorStringDescriptor;
 import com.intellij.util.io.KeyDescriptor;
 import com.reason.Log;
-import com.reason.Platform;
 import com.reason.StringUtil;
 import com.reason.bs.BsConfig;
 import com.reason.bs.BsConfigReader;
+import com.reason.ide.ORProjectManager;
 import com.reason.ide.files.DuneFile;
 import com.reason.ide.files.DuneFileType;
 import com.reason.lang.core.ORUtil;
 import com.reason.lang.core.psi.PsiStanza;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 public class NamespaceIndex extends ScalarIndexExtension<String> {
 
@@ -60,8 +59,8 @@ public class NamespaceIndex extends ScalarIndexExtension<String> {
             } else {
                 BsConfig configFile = BsConfigReader.read(dataFile);
                 if (configFile.hasNamespace()) {
-                    VirtualFile baseRoot = Platform.findORPackageJsonContentRoot(inputData.getProject());
-                    if (baseRoot != null) {
+                    Optional<VirtualFile> baseRoot = ORProjectManager.findFirstBsContentRoot(inputData.getProject());
+                    if (baseRoot.isPresent()) {
                         String namespace = configFile.getNamespace();
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("Indexing " + dataFile + " with namespace " + namespace);

--- a/tests/com/reason/ide/ORProjectManagerTest.java
+++ b/tests/com/reason/ide/ORProjectManagerTest.java
@@ -5,7 +5,9 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.GlobalSearchScope;
+import com.reason.bs.BsConstants;
 import com.reason.dune.DuneConstants;
+import com.reason.esy.EsyConstants;
 import com.reason.esy.EsyPackageJson;
 import com.reason.ide.files.BsConfigJsonFileType;
 import com.reason.ide.files.EsyPackageJsonFileType;
@@ -17,6 +19,7 @@ import org.mockito.stubbing.OngoingStubbing;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -40,6 +43,7 @@ public class ORProjectManagerTest {
     @Before
     public void setUp() {
         initMocks(this);
+        mockStatic(EsyPackageJson.class);
         mockStatic(FilenameIndex.class);
         mockStatic(GlobalSearchScope.class);
         when(GlobalSearchScope.allScope(mockProject)).thenReturn(mockScope);
@@ -56,15 +60,14 @@ public class ORProjectManagerTest {
     @Test
     public void testIsBsProject() {
         MockVirtualFile mockBsConfig = new MockVirtualFile(BsConfigJsonFileType.getDefaultFilename());
-        registerFilenameMock(mockBsConfig);
+        registerMockFile(mockBsConfig);
         assertTrue(ORProjectManager.isBsProject(mockProject));
     }
 
     @Test
     public void testIsEsyProject() {
-        mockStatic(EsyPackageJson.class);
         MockVirtualFile mockEsyConfig = new MockVirtualFile(EsyPackageJsonFileType.getDefaultFilename());
-        registerFilenameMock(mockEsyConfig);
+        registerMockFile(mockEsyConfig);
 
         OngoingStubbing<Boolean> whenIsEsyPackageJson = when(EsyPackageJson.isEsyPackageJson(mockEsyConfig));
 
@@ -80,51 +83,109 @@ public class ORProjectManagerTest {
         MockVirtualFile mockDuneFile = new MockVirtualFile(DuneConstants.DUNE_FILENAME);
         MockVirtualFile mockDuneProjectFile = new MockVirtualFile(DuneConstants.DUNE_PROJECT_FILENAME);
         MockVirtualFile mockJBuilderFile = new MockVirtualFile(DuneConstants.LEGACY_JBUILDER_FILENAME);
-        registerFilenameMock(mockDuneFile);
+        registerMockFile(mockDuneFile);
         assertTrue(ORProjectManager.isDuneProject(mockProject));
-        registerFilenameMock(mockDuneProjectFile);
+        registerMockFile(mockDuneProjectFile);
         assertTrue(ORProjectManager.isDuneProject(mockProject));
-        registerFilenameMock(mockJBuilderFile);
+        registerMockFile(mockJBuilderFile);
         assertTrue(ORProjectManager.isDuneProject(mockProject));
     }
 
     @Test
-    public void testFindDuneConfigurationFiles_prioritizeByFileType() {
+    public void testFindBsConfigurationFiles_sortedByFileDepth() {
+        String mockFileName = BsConstants.BS_CONFIG_FILENAME;
+        MockVirtualFile mockBsConfigFileParent = new MockVirtualFile(mockFileName);
+        MockVirtualFile mockBsConfigFile = new MockVirtualFile(mockFileName);
+        MockVirtualFile mockBsConfigFileChild = new MockVirtualFile(mockFileName);
+        // set up mock file hierarchy
+        mockBsConfigFile.setParent(mockBsConfigFileParent);
+        mockBsConfigFileChild.setParent(mockBsConfigFile);
+
+        MockVirtualFile[] mocksUnsorted = { mockBsConfigFile, mockBsConfigFileChild, mockBsConfigFileParent };
+        MockVirtualFile[] mocksSorted = { mockBsConfigFileParent, mockBsConfigFile, mockBsConfigFileChild };
+
+        when(FilenameIndex.getVirtualFilesByName(mockProject, mockFileName, mockScope))
+                .thenReturn(Arrays.asList(mocksUnsorted));
+
+        LinkedHashSet<VirtualFile> bsConfigurationFiles = ORProjectManager.findBsConfigurationFiles(mockProject);
+        assertMocksSorted(bsConfigurationFiles, mocksSorted);
+    }
+
+    @Test
+    public void testFindDuneConfigurationFiles_sortedByFileType() {
         MockVirtualFile mockDuneFile = new MockVirtualFile(DuneConstants.DUNE_FILENAME);
         MockVirtualFile mockDuneProjectFile = new MockVirtualFile(DuneConstants.DUNE_PROJECT_FILENAME);
         MockVirtualFile mockJBuilderFile = new MockVirtualFile(DuneConstants.LEGACY_JBUILDER_FILENAME);
 
-        MockVirtualFile[] mocksUnsorted = {
-                mockJBuilderFile,
-                mockDuneFile,
-                mockDuneProjectFile
-        };
-        MockVirtualFile[] mocksSorted = {
-                mockDuneProjectFile,
-                mockDuneFile,
-                mockJBuilderFile
-        };
+        MockVirtualFile[] mocksUnsorted = { mockJBuilderFile, mockDuneFile, mockDuneProjectFile };
+        MockVirtualFile[] mocksSorted = { mockDuneProjectFile, mockDuneFile, mockJBuilderFile };
 
         // test prioritizing of dune file types by registering mocks to be returned out of order
         for (MockVirtualFile mockFile : mocksUnsorted) {
-            registerFilenameMock(mockFile);
+            registerMockFile(mockFile);
         }
 
         LinkedHashSet<VirtualFile> duneConfigurationFiles = ORProjectManager.findDuneConfigurationFiles(mockProject);
-        assertEquals(mocksSorted.length, duneConfigurationFiles.size());
-        Iterator<VirtualFile> iterator = duneConfigurationFiles.iterator();
-        for (VirtualFile expected : mocksSorted) {
+        assertMocksSorted(duneConfigurationFiles, mocksSorted);
+    }
+
+    @Test
+    public void testFindDuneConfigurationFiles_sortedByFileDepth() {
+        String mockFileName = DuneConstants.DUNE_FILENAME;
+        MockVirtualFile mockDuneFileParent = new MockVirtualFile(mockFileName);
+        MockVirtualFile mockDuneFile = new MockVirtualFile(mockFileName);
+        MockVirtualFile mockDuneFileChild = new MockVirtualFile(mockFileName);
+        // set up mock file hierarchy
+        mockDuneFile.setParent(mockDuneFileParent);
+        mockDuneFileChild.setParent(mockDuneFile);
+
+        MockVirtualFile[] mocksUnsorted = { mockDuneFile, mockDuneFileChild, mockDuneFileParent };
+        MockVirtualFile[] mocksSorted = { mockDuneFileParent, mockDuneFile, mockDuneFileChild };
+
+        when(FilenameIndex.getVirtualFilesByName(mockProject, mockFileName, mockScope))
+                .thenReturn(Arrays.asList(mocksUnsorted));
+
+        LinkedHashSet<VirtualFile> duneConfigurationFiles = ORProjectManager.findDuneConfigurationFiles(mockProject);
+        assertMocksSorted(duneConfigurationFiles, mocksSorted);
+    }
+
+    @Test
+    public void testFindEsyConfigurationFiles_sortedByFileDepth() {
+        String mockFileName = EsyConstants.ESY_CONFIG_FILENAME;
+        MockVirtualFile mockEsyConfigFileParent = new MockVirtualFile(mockFileName);
+        MockVirtualFile mockEsyConfigFile = new MockVirtualFile(mockFileName);
+        MockVirtualFile mockEsyConfigFileChild = new MockVirtualFile(mockFileName);
+        // set up mock file hierarchy
+        mockEsyConfigFile.setParent(mockEsyConfigFileParent);
+        mockEsyConfigFileChild.setParent(mockEsyConfigFile);
+
+        MockVirtualFile[] mocksUnsorted = { mockEsyConfigFile, mockEsyConfigFileChild, mockEsyConfigFileParent };
+        MockVirtualFile[] mocksSorted = { mockEsyConfigFileParent, mockEsyConfigFile, mockEsyConfigFileChild };
+
+        when(FilenameIndex.getVirtualFilesByName(mockProject, mockFileName, mockScope))
+                .thenReturn(Arrays.asList(mocksUnsorted));
+
+        when(EsyPackageJson.isEsyPackageJson(any())).thenReturn(true);
+
+        LinkedHashSet<VirtualFile> esyConfigurationFiles = ORProjectManager.findEsyConfigurationFiles(mockProject);
+        assertMocksSorted(esyConfigurationFiles, mocksSorted);
+    }
+
+    private void registerMockFile(VirtualFile mockFile) {
+        registerMockFile(mockFile.getName(), mockFile);
+    }
+
+    private void registerMockFile(String filename, VirtualFile fileToReturn) {
+        when(FilenameIndex.getVirtualFilesByName(mockProject, filename, mockScope))
+                .thenReturn(Collections.singletonList(fileToReturn));
+    }
+
+    private void assertMocksSorted(LinkedHashSet<VirtualFile> actualOrder, VirtualFile[] expectedOrder) {
+        assertEquals(expectedOrder.length, actualOrder.size());
+        Iterator<VirtualFile> iterator = actualOrder.iterator();
+            for (VirtualFile expected : expectedOrder) {
             VirtualFile next = iterator.next();
             assertEquals(expected, next);
         }
-    }
-
-    private void registerFilenameMock(VirtualFile mockFile) {
-        registerFilenameMock(mockFile.getName(), mockFile);
-    }
-
-    private void registerFilenameMock(String filename, VirtualFile fileToReturn) {
-        when(FilenameIndex.getVirtualFilesByName(mockProject, filename, mockScope))
-                .thenReturn(Collections.singletonList(fileToReturn));
     }
 }


### PR DESCRIPTION
Found configuration files are now sorted by depth. Files closer to the root of the filesystem are returned first.

Example:
```
Before Sorting:
 - <project-dir>/packages/somePackage/bsconfig.json
 - <project-dir>/packages/somePackage/lib/bsconfig.json
 - <project-dir>/bsconfig.json

After Sorting:
 - <project-dir>/bsconfig.json
 - <project-dir>/packages/somePackage/bsconfig.json
 - <project-dir>/packages/somePackage/lib/bsconfig.json
```

- Also replaced Platform methods with ORProjectManager methods.

 - Removed unused code.

Next up: add tests to BsProcess and DuneProcess constructors to ensure warning notifications are displayed if executables are missing.